### PR TITLE
Fix Webpack OpenSSL issue with Node.js 17+

### DIFF
--- a/.env
+++ b/.env
@@ -1,0 +1,1 @@
+NODE_OPTIONS=--openssl-legacy-provider

--- a/README.md
+++ b/README.md
@@ -1,1 +1,17 @@
-This repository is empty. Any task executed on it should be considered a new capability and needs to be created.
+# CampusSys
+
+## Webpack OpenSSL Issue with Node.js 17+
+
+When using Node.js 17 or newer, you may encounter an issue with Webpack due to changes in OpenSSL. To resolve this issue, we need to set the environment variable `NODE_OPTIONS=--openssl-legacy-provider`.
+
+### Solution
+
+1. **package.json**: The `build` and `start` scripts in `package.json` have been updated to include `NODE_OPTIONS=--openssl-legacy-provider` before `react-scripts build` and `react-scripts start`.
+
+2. **.env file**: A `.env` file has been added to the repository with the following content to ensure compatibility during development:
+
+   ```
+   NODE_OPTIONS=--openssl-legacy-provider
+   ```
+
+By setting this environment variable, we ensure that the application works correctly with Node.js 17+.

--- a/package.json
+++ b/package.json
@@ -4,8 +4,8 @@
   "description": "A web application for students and teachers within the campus.",
   "main": "src/index.js",
   "scripts": {
-    "start": "react-scripts start",
-    "build": "react-scripts build",
+    "start": "NODE_OPTIONS=--openssl-legacy-provider react-scripts start",
+    "build": "NODE_OPTIONS=--openssl-legacy-provider react-scripts build",
     "test": "react-scripts test",
     "eject": "react-scripts eject"
   },


### PR DESCRIPTION
Update the React project to fix the Webpack OpenSSL issue with Node.js 17+.

* **package.json**: Update the `start` and `build` scripts to include `NODE_OPTIONS=--openssl-legacy-provider` before `react-scripts start` and `react-scripts build`.
* **README.md**: Add a section explaining the Webpack OpenSSL issue with Node.js 17+ and the solution involving `NODE_OPTIONS=--openssl-legacy-provider`. Mention the updates to `package.json` and the addition of the `.env` file.
* **.env**: Add a new `.env` file with `NODE_OPTIONS=--openssl-legacy-provider` to ensure compatibility during development.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/HugeSmile01/CampusSys/pull/5?shareId=3e53e603-0810-4354-b81f-acf6512886f8).